### PR TITLE
Add PHP 7.x and SMF 2.0.15 support.

### DIFF
--- a/Sources/PortaMx/Class/System/PortaMx_AdminArticlesClass.php
+++ b/Sources/PortaMx/Class/System/PortaMx_AdminArticlesClass.php
@@ -27,7 +27,7 @@ class PortaMxC_AdminArticles
 	* Saved the config, load the article css file if exist.
 	* Have the article a css file, the class definition is extracted from ccs header
 	*/
-	function PortaMxC_AdminArticles($config)
+	function __construct($config)
 	{
 		global $context, $settings;
 

--- a/Sources/PortaMx/Class/System/PortaMx_AdminBlocksClass.php
+++ b/Sources/PortaMx/Class/System/PortaMx_AdminBlocksClass.php
@@ -28,7 +28,7 @@ class PortaMxC_AdminBlocks
 	* Saved the config, load the block css if exist.
 	* Have the block a css file, the class definition is extracted from ccs header
 	*/
-	function PortaMxC_AdminBlocks($blockconfig)
+	function __construct($blockconfig)
 	{
 		global $context, $settings;
 

--- a/Sources/PortaMx/Class/System/PortaMx_AdminCategoriesClass.php
+++ b/Sources/PortaMx/Class/System/PortaMx_AdminCategoriesClass.php
@@ -27,7 +27,7 @@ class PortaMxC_AdminCategories
 	* Saved the config, load the category css file if exist.
 	* Have the category a css file, the class definition is extracted from ccs header
 	*/
-	function PortaMxC_AdminCategories($config)
+	function __construct($config)
 	{
 		global $context, $settings;
 

--- a/Sources/PortaMx/Class/System/PortaMx_BlocksClass.php
+++ b/Sources/PortaMx/Class/System/PortaMx_BlocksClass.php
@@ -36,7 +36,7 @@ class PortaMxC_Blocks
 	* Saved the config and checks the visiblity access.
 	* If access true, the block css file is loaded if exist.
 	*/
-	function PortaMxC_Blocks($blockconfig, &$visible)
+	function __construct($blockconfig, &$visible)
 	{
 		global $context, $options, $user_info, $settings, $mbname, $scripturl, $modSettings, $maintenance;
 

--- a/install/pmxinstall.xml
+++ b/install/pmxinstall.xml
@@ -260,15 +260,17 @@ function loadUserSettings()
 {
 	global $modSettings, $user_settings, $sourcedir, $smcFunc;
 	global $cookiename, $user_info, $language;
+	global $boardurl, $image_proxy_enabled, $image_proxy_secret;
 
 	// Check first the integration, then the cookie, and last the session.
 	if (count($integration_ids = call_integration_hook('integrate_verify_user')) > 0)
 ]]></search>
 			<add><![CDATA[
-function loadUserSettings($checkOnly = false)
+function loadUserSettings()
 {
 	global $modSettings, $user_settings, $sourcedir, $smcFunc;
 	global $cookiename, $user_info, $language;
+	global $boardurl, $image_proxy_enabled, $image_proxy_secret;
 
 	// Check first the integration, then the cookie, and last the session.
 	if (empty($checkOnly) && count($integration_ids = call_integration_hook('integrate_verify_user')) > 0)
@@ -384,7 +386,7 @@ function loadSession()
 			<search position="before"><![CDATA[
 function Login()
 {
-	global $txt, $context, $scripturl;
+	global $txt, $context, $scripturl, $smcFunc;
 ]]></search>
 			<add><![CDATA[
 	if(!pmx_checkECL_Cookie())


### PR DESCRIPTION
Pulls in the updated archive "PortaMx Portal 1.54 ECL for SMF 2.0.x" from https://www.portamx.com/pages/downloads-portamx/ with the following changes:

> Archive updated for SMF 2.0.15 and PHP 7.x (13. March 2018, 16:00)