### PR TITLE
Fix for PortaMx 1.54 ecl - Portal Login-Block Problem on SMF 2.0.15.

### DIFF
--- a/Sources/PortaMx/Class/user_login.php
+++ b/Sources/PortaMx/Class/user_login.php
@@ -109,6 +109,7 @@ class pmxc_user_login extends PortaMxC_SystemBlock
 				echo '
 									<div style="padding-top:4px;">
 										<form action="'. $scripturl .'?action=login2" method="post">
+											<input type="hidden" name="', $context['session_var'], '" value="', $context['session_id'], '" />
 											<input type="text" name="user" value="" style="width:42%;float:'. $L_R .';margin-bottom:3px;" />
 											<input type="password" name="passwrd" value="" style="width:42%;float:'. $R_L .';margin-bottom:3px;margin-'. $R_L .':4px;" />';
 


### PR DESCRIPTION
Pulls in the "Fix for PortaMx 1.54 ecl - Portal Login-Block Problem on SMF 2.0.15" from https://www.portamx.com/pages/downloads-portamx/ with the following changes:

> This small update fixed the login on SMF 2.0.15 with the Portal Login Block.
Extract the archive and copy the file (user_login.php) to your server in the path [forum:root]/Sources/PortaMx/Class/ and overwrite the existing file.
Now the Portal login block will works correctly.