### PR TITLE
Fix "[] operator not supported for strings" messages on spages

### DIFF
--- a/Sources/PortaMx/PortaMx.php
+++ b/Sources/PortaMx/PortaMx.php
@@ -331,7 +331,7 @@ function pmx_MakeLinktree()
 		$context['page_title'] = $context['forum_name'];
 
 	// build the linktree
-	$pmxforum = '';
+	$pmxforum = array();
 	if(empty($context['linktree']))
 		$context['linktree'] = array(array('url' => $scripturl, 'name' => $mbname));
 


### PR DESCRIPTION
Fixes the following error on newer PHP 7.x versions when accessing a single page:

```
https://example.com/index.php?spage=example
[] operator not supported for strings
```

Pulled in from https://www.portamx.com/smf-2-modifications-and-portamx/smf-2015-portamx-154-operator-not-supported-for-strings/msg21495/#msg21495