### PR TITLE
Fix not needed str_replace() call.

### DIFF
--- a/Sources/PortaMx/AdminArticles.php
+++ b/Sources/PortaMx/AdminArticles.php
@@ -402,9 +402,6 @@ function PortaMx_AdminArticles()
 							pmxPHP_convert();
 					}
 
-					// remove relative pathes/urls in content
-					$_POST['content'] = str_replace('/fckeditor/editor/../..', '', $_POST['content']);
-
 					// get all data
 					$article = array(
 						'id' => $_POST['id'],


### PR DESCRIPTION
As suggested by a user in https://www.portamx.com/bug-reports/existing-replacement-call-for-fckeditor-in-153-not-removedupdated/msg18997/#msg18997 cleaning up a leftover from the migration from fckeditor to ckeditor in 55fd80148d7105fc830cee7a300144d9fc802c6a